### PR TITLE
Metadata and doc improvements

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl package Data::Beacon
 
 0.3.1 2014-03-
     - Added abstract to pod, so tools like MetaCPAN can find it
+    - Added author and copyright/license sections to pod
 
 0.3.0 2012-12-04*
     - removed BEACON collection handling

--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Revision history for Perl package Data::Beacon
 0.3.1 2014-03-
     - Added abstract to pod, so tools like MetaCPAN can find it
     - Added author and copyright/license sections to pod
+    - Specified 5.8.0 as min version of perl
 
 0.3.0 2012-12-04*
     - removed BEACON collection handling

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Revision history for Perl package Data::Beacon
     - Added author and copyright/license sections to pod
     - Specified 5.8.0 as min version of perl
     - Added [AutoPrereqs] to dist.ini so Makefile.PL will get PREREQ_PM
+    - Added =encoding utf8 to pod, since the pod now contains UTF-8 chars
 
 0.3.0 2012-12-04*
     - removed BEACON collection handling

--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl package Data::Beacon
 ==============================================
 '*' indicates a revision also published at CPAN.
 
+0.3.1 2014-03-
+    - Added abstract to pod, so tools like MetaCPAN can find it
+
 0.3.0 2012-12-04*
     - removed BEACON collection handling
 

--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for Perl package Data::Beacon
     - Added abstract to pod, so tools like MetaCPAN can find it
     - Added author and copyright/license sections to pod
     - Specified 5.8.0 as min version of perl
+    - Added [AutoPrereqs] to dist.ini so Makefile.PL will get PREREQ_PM
 
 0.3.0 2012-12-04*
     - removed BEACON collection handling

--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ author           = Jakob Voß
 copyright_holder = Jakob Voß
 
 [@Basic]
+[AutoPrereqs]
 
 [PruneFiles]
 filename=README.md

--- a/lib/Data/Beacon.pm
+++ b/lib/Data/Beacon.pm
@@ -11,6 +11,10 @@ use Carp;
 use base 'Exporter';
 our @EXPORT = qw(plainbeaconlink beacon);
 
+=head1 NAME
+
+Data::Beacon - BEACON format validating parser and serializer
+
 =head1 DESCRIPTION
 
 THIS MODULE DOES NOT REFLECT THE CURRENT STATE OF BEACON SPECIFICATION!

--- a/lib/Data/Beacon.pm
+++ b/lib/Data/Beacon.pm
@@ -3,6 +3,7 @@ use warnings;
 package Data::Beacon;
 #ABSTRACT: BEACON format validating parser and serializer
 
+use 5.008;
 use Time::Piece;
 use Scalar::Util qw(blessed);
 use URI::Escape;

--- a/lib/Data/Beacon.pm
+++ b/lib/Data/Beacon.pm
@@ -12,6 +12,8 @@ use Carp;
 use base 'Exporter';
 our @EXPORT = qw(plainbeaconlink beacon);
 
+=encoding utf8
+
 =head1 NAME
 
 Data::Beacon - BEACON format validating parser and serializer

--- a/lib/Data/Beacon.pm
+++ b/lib/Data/Beacon.pm
@@ -1041,4 +1041,15 @@ development snapshot, bug reports, feature requests, and such.
 See also L<SeeAlso::Server> for an API to exchange single sets of 
 beacon links, based on the same source identifier.
 
+=head1 AUTHOR
+
+Jakob Voß E<lt>jakob.voss@gbv.deE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2010 by Jakob Voß E<lt>jakob.voss@gbv.deE<gt>.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
 =cut


### PR DESCRIPTION
Hi Jakob,

I've made a number of small changes to follow conventions for metadata and pod:
- Added abstract (=head1 NAME). MetaCPAN wasn't finding an abstract for the module, which means it
  presents the module slightly differently from other modules.
- Added author and license/copyright details to pod
- Added [AutoPrereqs] to dist.ini, so Makefile.PL will list the prereqs

Cheers,
Neil
